### PR TITLE
Remove Hashlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ubirch-protocol==2.1.0
 tinydb==3.14.1
 requests==2.22.0
-hashlib


### PR DESCRIPTION
hashlib as an external dependency is incompatible with python3.
Python3 comes w/ its own version of hashlib builtin, therefore
it is not required to install it.